### PR TITLE
Update lowpower.py to use bitwise addition for setting wake bits

### DIFF
--- a/lowpower.py
+++ b/lowpower.py
@@ -62,8 +62,8 @@ def dormant_with_modes(pin_modes):
 
         if en_reg not in registers_events:
             registers_events[en_reg] = 0
-
-        registers_events[en_reg] = registers_events[en_reg] + pin_mode << 4 * (gpio_pin % 8)
+        # Use bitwise addition instead of `+`
+        registers_events[en_reg] = registers_events[en_reg] | ( pin_mode << 4 * (gpio_pin % 8) )
 
     # Enable Wake-up from GPIO IRQ
     for en_reg, events in registers_events.items():

--- a/lowpower.py
+++ b/lowpower.py
@@ -62,7 +62,6 @@ def dormant_with_modes(pin_modes):
 
         if en_reg not in registers_events:
             registers_events[en_reg] = 0
-        # Use bitwise addition instead of `+`
         registers_events[en_reg] = registers_events[en_reg] | ( pin_mode << 4 * (gpio_pin % 8) )
 
     # Enable Wake-up from GPIO IRQ


### PR DESCRIPTION
On my device when testing with multiple pins, I found that only one of them was responding.
After researching, I found the python library was concatenating the events instead of performing addition.

This change uses bitwise addition to ensure that it does not stringify the data.